### PR TITLE
updated environment.yml to more recent package versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pyiron.db
 pyiron.log
 *_analysis/
 .ipynb_checkpoints/
+nohup.out

--- a/environment.yml
+++ b/environment.yml
@@ -2,9 +2,14 @@ name: pmd-demonstrator
 channels:
 - conda-forge
 dependencies:
-- python =3.8
-- pyiron_base =0.6.1
+- python =3.10
+- ipykernel =6.28.0
+- matplotlib =3.8.2
+- pandas =2.1.4
+- papermill =2.4.0
+- pyiron_base =0.6.20
+- rdflib =7.0.0
 - requests =2.31.0
+- scipy =1.11.4
 - sparqlwrapper =2.0.0
-- matplotlib =3.4.3
-- papermill
+- tabulate  =0.9.0

--- a/pyiron_tensile_test/tensile_test_job.py
+++ b/pyiron_tensile_test/tensile_test_job.py
@@ -2,7 +2,7 @@ from pyiron_base import PythonTemplateJob, DataContainer
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
-from sklearn.linear_model import LinearRegression
+#from sklearn.linear_model import LinearRegression
 from scipy.optimize import curve_fit
 import requests
 from SPARQLWrapper import SPARQLWrapper, JSON


### PR DESCRIPTION
# Updated `environment.yml`
- migrate to python 3.10
- use recent package versions
- complete list of required packages. I did not dig into why some packages had to be added, I guess they were just missing before.

With the updated `environment.yml`, a user can just do something like `conda env create --file environment.yml`. Actually, packages `jupyter`, `nglview` and perhaps `nodejs` also might have to be installed for the jupyter (lab) interface to work in the newly created env. Because this depends on the users setup and preferences, none of this is added at this point.

# minor changes
- `sklearn` is not required, to I commented out the import statemant in `pyiron_tensile_test/tensile_test_job.py`
- added `nohup.out` to `.gitignore` because it is more convenient for me.